### PR TITLE
infra: Create S3 bucket pavlo-ait-feature4 in Frankfurt region

### DIFF
--- a/development/eu-central-1/s3/pavlo-ait-feature4/.terraform.lock.hcl
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0, >= 5.83.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/development/eu-central-1/s3/pavlo-ait-feature4/main.tf
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/main.tf
@@ -1,0 +1,21 @@
+module "s3_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 4.0"
+
+  bucket = "pavlo-ait-feature4"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  versioning = {
+    enabled = false
+  }
+
+  tags = {
+    Environment = "development"
+    ManagedBy   = "terraform"
+    Project     = "poc"
+  }
+}

--- a/development/eu-central-1/s3/pavlo-ait-feature4/provider.tf
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/provider.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "eu-central-1"
+  profile = "816069152945-admin"
+
+  assume_role {
+    role_arn = "arn:aws:iam::816069152945:role/terraform"
+  }
+}

--- a/development/eu-central-1/s3/pavlo-ait-feature4/terraform.tfstate
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/terraform.tfstate
@@ -1,0 +1,8 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.2",
+  "serial": 0,
+  "lineage": "pavlo-ait-feature4-initial",
+  "outputs": {},
+  "resources": []
+}


### PR DESCRIPTION
## DevOps Task: Create S3 bucket pavlo-ait-feature4 in Frankfurt region



**Artifact Type:** 
**Risk Level:** 
**Affected Systems:** N/A

### Files
- `development/eu-central-1/s3/pavlo-ait-feature4/provider.tf` -- Terraform provider configuration for eu-central-1 region with AWS 5.0 provider and role assumption
- `development/eu-central-1/s3/pavlo-ait-feature4/main.tf` -- S3 bucket module configuration for pavlo-ait-feature4 with public access blocking and default security settings
- `development/eu-central-1/s3/pavlo-ait-feature4/.terraform.lock.hcl` -- Terraform lock file pinning AWS provider version 5.100.0
- `development/eu-central-1/s3/pavlo-ait-feature4/terraform.tfstate` -- Initialize empty Terraform state file for pavlo-ait-feature4

---
*Auto-generated by DevOps AI Assistant -- IaC Generator*