### PR TITLE
infra: Create S3 bucket pavlo-ait-feature4 in Frankfurt region

### DIFF
--- a/development/eu-central-1/s3/pavlo-ait-feature4/main.tf
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/main.tf
@@ -1,0 +1,21 @@
+module "s3_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 4.0"
+
+  bucket = "pavlo-ait-feature4"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  versioning = {
+    enabled = true
+  }
+
+  tags = {
+    Environment = "development"
+    ManagedBy   = "terraform"
+    Project     = "poc"
+  }
+}

--- a/development/eu-central-1/s3/pavlo-ait-feature4/outputs.tf
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_id" {
+  description = "The name of the S3 bucket"
+  value       = module.s3_bucket.s3_bucket_id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket"
+  value       = module.s3_bucket.s3_bucket_arn
+}
+
+output "bucket_region" {
+  description = "The AWS region where the S3 bucket is deployed"
+  value       = "eu-central-1"
+}
+
+output "versioning_enabled" {
+  description = "Whether versioning is enabled on the bucket"
+  value       = true
+}

--- a/development/eu-central-1/s3/pavlo-ait-feature4/provider.tf
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/provider.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "eu-central-1"
+  profile = "816069152945-admin"
+
+  assume_role {
+    role_arn = "arn:aws:iam::816069152945:role/terraform"
+  }
+}

--- a/development/eu-central-1/s3/pavlo-ait-feature4/variables.tf
+++ b/development/eu-central-1/s3/pavlo-ait-feature4/variables.tf
@@ -1,0 +1,21 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+  default     = "pavlo-ait-feature4"
+}
+
+variable "enable_versioning" {
+  description = "Enable versioning on the S3 bucket"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to the S3 bucket"
+  type        = map(string)
+  default = {
+    Environment = "development"
+    ManagedBy   = "terraform"
+    Project     = "poc"
+  }
+}


### PR DESCRIPTION
## DevOps Task: Create S3 bucket pavlo-ait-feature4 in Frankfurt region

Acceptance criteria:
- S3 with versioning enabled
- S3 deployed in Frankfurt region

**Artifact Type:** 
**Risk Level:** 
**Affected Systems:** N/A

### Files
- `development/eu-central-1/s3/pavlo-ait-feature4/provider.tf` -- Terraform provider configuration for AWS eu-central-1 region with role assumption
- `development/eu-central-1/s3/pavlo-ait-feature4/main.tf` -- S3 bucket module configuration with versioning enabled and public access blocks
- `development/eu-central-1/s3/pavlo-ait-feature4/variables.tf` -- Variables file for S3 bucket configuration
- `development/eu-central-1/s3/pavlo-ait-feature4/outputs.tf` -- Outputs file for S3 bucket information

---
*Auto-generated by DevOps AI Assistant -- IaC Generator*